### PR TITLE
[FIX] : fixed last user message in qr command 

### DIFF
--- a/src/commands/QrCommand.ts
+++ b/src/commands/QrCommand.ts
@@ -53,7 +53,7 @@ export class QrCommand implements ISlashCommand {
 			context.getSender().id,
 		);
 
-		const lastOtherUserMessage = prevMessages.find(message => 
+		const lastUserMessage = prevMessages.find(message => 
 			message.text &&
 			message.sender.username !== sender.username
 		);
@@ -68,9 +68,9 @@ export class QrCommand implements ISlashCommand {
 		const AiHandler = new AIHandler(this.app, http, Preference);
 
 		let items = [] as ISlashCommandPreviewItem[];
-		if (lastOtherUserMessage?.text) {
+		if (lastUserMessage?.text) {
 			const data = await AiHandler.handleResponse(
-				lastOtherUserMessage.text,
+				lastUserMessage.text,
 				'',
 				true,
 			);

--- a/src/lib/Translation/locales/en.ts
+++ b/src/lib/Translation/locales/en.ts
@@ -86,4 +86,6 @@ export const en = {
 	AI_Gemini_Model_Not_Configured: "Your Gemini Model is not set up properly. Please check your configuration",
 	AI_Workspace_Model_Not_Configured: "Your Workspace AI is not set up properly. Please contact your administrator",
 	AI_Something_Went_Wrong: "Something went wrong. Please try again later.",
-	Refresh_Button_Text: "Refresh"};
+	Refresh_Button_Text: "Refresh",
+	No_User_Reply_Found: "No messages from other users found to respond to."
+}

--- a/src/lib/Translation/locales/en.ts
+++ b/src/lib/Translation/locales/en.ts
@@ -87,5 +87,5 @@ export const en = {
 	AI_Workspace_Model_Not_Configured: "Your Workspace AI is not set up properly. Please contact your administrator",
 	AI_Something_Went_Wrong: "Something went wrong. Please try again later.",
 	Refresh_Button_Text: "Refresh",
-	No_User_Reply_Found: "No messages from other users found to respond to."
+	No_User_Reply_Found: "❌ No messages from other users found to respond to."
 }


### PR DESCRIPTION
## Issue(s)

#18

## Acceptance Criteria fulfillment

- [x] Ai now have the last other users message to generate replies
- [x] If no user reply found , error notification is sent to user

###Testing and demo 
[Screencast from 2025-02-24 07-00-38.webm](https://github.com/user-attachments/assets/087d4378-8a7a-4a09-810d-385cb5b93c35)


**Note** - i found that quick replies do get other users message in a different pattern which is 


`const roomId = room.id;
		const roomMessages = await read
			.getRoomReader()
			.getMessages(roomId);
		const lastMessage = roomMessages.pop();
		const Message =
			lastMessage?.text ||
			lastMessage?.attachments?.[0]?.description ||
			'';
`


this and i implemented that as well but in the time where there is no message of other user in the room it took the last message available in the room rather then showing error so i opted for the way i committed which finds the message based on the user name 

**here is the proof of my raised statement**
![Screenshot from 2025-02-24 07-11-57](https://github.com/user-attachments/assets/81f8366f-7784-4157-8bea-60036b35467e)


here you can see both works exactly fine when comes to get other users message but in the case where there is no other user message the above command gets the last message in the room 